### PR TITLE
Fix setup-tools.sh and remove ED64Plus Lockout

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1280,7 +1280,8 @@ void rom_load_y(void)
     fr = f_stat(gb_sram_file2, &fno);
     if (fr == FR_OK) 
     {
-        gb_load_y = 1;
+	    // Remove check for ED64Plus
+	    //        gb_load_y = 0;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -142,7 +142,6 @@ u16 cursor_history_pos = 0;
 
 u8 empty = 0;
 int mp3playing = 0;
-u8 gb_load_y = 0;
 
 FATFS *fs;
 
@@ -1267,23 +1266,6 @@ void loadggrom(display_context_t disp, TCHAR *rom_path) //TODO: this could be me
     }   
 }
 
-void rom_load_y(void)
-{
-    FRESULT fr;
-    FILINFO fno;
-
-    u8 gb_sram_file[64];
-    u8 gb_sram_file2[64];
-    sprintf(gb_sram_file, "%c%c%c%c%c%c%c", 'O', 'S', '6', '4', 'P', '/', 'O');
-    sprintf(gb_sram_file2, "%s%c%c%c%c%c%c%c%c", gb_sram_file, 'S', '6', '4', 'P', '.', 'v', '6', '4');
-
-    fr = f_stat(gb_sram_file2, &fno);
-    if (fr == FR_OK) 
-    {
-	    // Remove check for ED64Plus
-	    //        gb_load_y = 0;
-    }
-}
 
 void loadnesrom(display_context_t disp, TCHAR *rom_path)
 {
@@ -1629,7 +1611,6 @@ int backupSaveData(display_context_t disp)
 //write a cart-save from a file to the fpga/cart
 int saveTypeFromSd(display_context_t disp, char *rom_name, int stype)
 {
-    rom_load_y();
     TRACE(disp, rom_filename);
     TCHAR fname[256] = {0};
     sprintf(fname, "/ED64/%s/%s.%s", save_path, rom_name, saveTypeToExtension(stype, ext_type));
@@ -1700,24 +1681,22 @@ int saveTypeFromSd(display_context_t disp, char *rom_name, int stype)
         return 0;
     }
 
-    if (gb_load_y != 1)
+
+    if (pushSaveToCart(stype, cartsave_data))
     {
-        if (pushSaveToCart(stype, cartsave_data))
-        {
-            printText("transferred save data...", 3, -1, disp);
-        }
-        else
-        {
-            printText("error transfering save data", 3, -1, disp);
-        }
+        printText("transferred save data...", 3, -1, disp);
     }
+    else
+    {
+        printText("error transfering save data", 3, -1, disp);
+    }
+
 
     return 1;
 }
 
 int saveTypeToSd(display_context_t disp, char *rom_name, int stype)
 {
-    rom_load_y();
     //after reset create new savefile
     TCHAR fname[256]; //TODO: change filename buffers to 256!!!
 
@@ -1744,17 +1723,15 @@ int saveTypeToSd(display_context_t disp, char *rom_name, int stype)
         if (getSaveFromCart(stype, cartsave_data))
         {
             //write to file
-            if (gb_load_y != 1)
-            {
-                UINT bw;
-                result = f_write (
-                    &file,          /* [IN] Pointer to the file object structure */
-                    cartsave_data, /* [IN] Pointer to the data to be written */
-                    size,         /* [IN] Number of bytes to write */
-                    &bw          /* [OUT] Pointer to the variable to return number of bytes written */
-                  );
-                  f_close(&file);
-            }
+            UINT bw;
+            result = f_write (
+                &file,          /* [IN] Pointer to the file object structure */
+                cartsave_data, /* [IN] Pointer to the data to be written */
+                size,         /* [IN] Number of bytes to write */
+                &bw          /* [OUT] Pointer to the variable to return number of bytes written */
+            );
+            f_close(&file);
+            
     
             printText("RAM area copied to SD card.", 3, -1, disp);
             return 1;

--- a/tools/setup-linux.sh
+++ b/tools/setup-linux.sh
@@ -9,7 +9,7 @@ apt-get update
 apt-get -y upgrade
 
 # Install essential packages [sudo req.]
-apt-get -y install build-essential git texinfo libc6 libgmp-dev libmpfr-dev libmpc-dev libpng-dev zlib1g-dev libtool autoconf
+apt-get -y install wget build-essential git texinfo libc6 libgmp-dev libmpfr-dev libmpc-dev libpng-dev zlib1g-dev libtool autoconf
 
 # change to the users root directory
 cd ~/
@@ -22,6 +22,8 @@ export N64_INST=/usr/local/libdragon
 
 # Pull the latest libdragon source code and make a build directory
 git clone https://github.com/dragonminded/libdragon.git
+# set to correct commit
+cd libdragon && git checkout b26fce6 && cd ..
 
 # fix issues with the build scripts
 sed -i -- 's|${N64_INST:-/usr/local}|/usr/local/libdragon|g' libdragon/tools/build
@@ -70,7 +72,7 @@ make install
 cd ..
 # install libmad (custom version)
 git clone https://github.com/n64-tools/libmad
-cd libmad-n64
+cd libmad
 export PATH=$PATH:$N64_INST/bin
 CFLAGS="-std=gnu99 -march=vr4300 -mtune=vr4300" \
 LDFLAGS="-L$N64_INST/lib -Tn64ld.x" \


### PR DESCRIPTION
This PR fixes the setup tools script by:
- adding wget, as it may not be part of the linux distro
- checkout the last working commit of libdragon instead of building from master

Also it removes the lockout for ED64Plus Everdrive clone.