### PR TITLE
Eeprom filesizes were incorrect, fixed this. (One bit is not a byte)

### DIFF
--- a/inc/rom.h
+++ b/inc/rom.h
@@ -129,7 +129,7 @@
 #define	IO_WRITE(addr,data)	(*(volatile u32*)PHYS_TO_K1(addr)=(u32)(data))
 
 #define SAVE_SIZE_SRAM 		32768
-#define SAVE_SIZE_SRAM96 	131072 //TODO: or should this be 98304
+#define SAVE_SIZE_SRAM96 	131072
 #define SAVE_SIZE_EEP4k 	512
 #define SAVE_SIZE_EEP16k 	2048
 #define SAVE_SIZE_FLASH 	131072

--- a/inc/rom.h
+++ b/inc/rom.h
@@ -130,8 +130,8 @@
 
 #define SAVE_SIZE_SRAM 		32768
 #define SAVE_SIZE_SRAM96 	131072 //TODO: or should this be 98304
-#define SAVE_SIZE_EEP4k 	4096
-#define SAVE_SIZE_EEP16k 	16384
+#define SAVE_SIZE_EEP4k 	512
+#define SAVE_SIZE_EEP16k 	2048
 #define SAVE_SIZE_FLASH 	131072
 
 #define ROM_ADDR 		0xb0000000


### PR DESCRIPTION
An ED64 owner was complaining to me about EEPROM filesizes being different (and thus incompatible unless trimmed) from the Everdrive64 firmware.
Turns out the save sizes for those is incorrect so it should fix this.

No idea about SAVE_SIZE_SRAM96 though, i guess this should be compared against the stock firmware. I wonder what games use those ?