### PR TITLE
Fix building on wsl2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ HEADERNAME = header.ed64
 HEADERTITLE = "EverDrive OS"
 PROG_NAME = OS64
 
-INCLUDE_DIRS = -I$(ROOTDIR)/inc -I$(ROOTDIR)/include -I$(ROOTDIR)/toolchain/gcc-toolchain-mips64/include -I$(ROOTDIR)/toolchain/gcc-toolchain-mips64/mips64-elf/include -I$(ROOTDIR)/toolchain/libdragon/include
+INCLUDE_DIRS = -I$(ROOTDIR)/inc -I$(ROOTDIR)/include -I$(ROOTDIR)/toolchain/gcc-toolchain-mips64-win64/include -I$(ROOTDIR)/toolchain/gcc-toolchain-mips64-win64/mips64-elf/include -I$(ROOTDIR)/toolchain/libdragon/include
 
 COMMON_FLAGS = -std=gnu17 -march=vr4300 -mtune=vr4300 -Wall -Wrestrict -Wno-pointer-sign -D_REENTRANT -DUSE_TRUETYPE $(INCLUDE_DIRS) $(SET_DEBUG)
 FLAGS_VT = -O0 $(COMMON_FLAGS)
 FLAGS = -O2 $(COMMON_FLAGS)
 ASFLAGS = -mtune=vr4300 -march=vr4300
-LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/toolchain/gcc-toolchain-mips64/mips64-elf/lib -L$(ROOTDIR)/toolchain/libdragon/lib -ldragon -lmikmod -lmad -lyaml -lm -lc -ldragonsys -Tn64ld.x
+LINK_FLAGS = -G0 -L$(ROOTDIR)/lib -L$(ROOTDIR)/toolchain/gcc-toolchain-mips64-win64/mips64-elf/lib -L$(ROOTDIR)/toolchain/libdragon/lib -ldragon -lmikmod -lmad -lyaml -lm -lc -ldragonsys -Tn64ld.x
 
-GCCN64PREFIX = $(ROOTDIR)/toolchain/gcc-toolchain-mips64/bin/mips64-elf-
+GCCN64PREFIX = $(ROOTDIR)/toolchain/gcc-toolchain-mips64-win64/bin/mips64-elf-
 CC = $(GCCN64PREFIX)gcc.exe
 AS = $(GCCN64PREFIX)as.exe
 LD = $(GCCN64PREFIX)ld.exe

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-set PATH=%~dp0toolchain\gcc-toolchain-mips64\bin
+set PATH=%~dp0toolchain\gcc-toolchain-mips64-win64\bin
 @echo off
 
 IF %1.==. (

--- a/update-libs.ps1
+++ b/update-libs.ps1
@@ -10,7 +10,7 @@ $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/mips64-gcc-too
 $output = "$PSScriptRoot\temp\gcc-toolchain-mips64.zip"
 
 Invoke-WebRequest -Uri $url -OutFile $output
-Expand-Archive -Force -Path $output -DestinationPath "$PSScriptRoot\toolchain\gcc-toolchain-mips64\"
+Expand-Archive -Force -Path $output -DestinationPath "$PSScriptRoot\toolchain\"
 
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/libs/n64/latest/libmikmod.zip"
 $output = "$PSScriptRoot\temp\libmikmod.zip"

--- a/update-libs.ps1
+++ b/update-libs.ps1
@@ -1,35 +1,47 @@
 New-Item -ItemType Directory -Force -Path "$PSScriptRoot\temp\"
 
+$ProgressPreference = 'SilentlyContinue'
+
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/libdragon/develop/latest/libdragon-win64.zip"
 $output = "$PSScriptRoot\temp\libdragon.zip"
 
-Invoke-WebRequest -Uri $url -OutFile $output
+Write-Host "Downloading libdragon-win64.zip...." -NoNewline
+Invoke-RestMethod -ContentType "application/octet-stream" -Uri $url -OutFile $output
+Write-Host "Done."
 Expand-Archive -Force -Path $output -DestinationPath "$PSScriptRoot\toolchain\libdragon\"
 
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/mips64-gcc-toolchain/master/latest/gcc-toolchain-mips64-win64.zip"
 $output = "$PSScriptRoot\temp\gcc-toolchain-mips64.zip"
 
-Invoke-WebRequest -Uri $url -OutFile $output
+Write-Host "Downloading gcc-toolchain-mips64.zip...." -NoNewline
+Invoke-RestMethod -ContentType "application/octet-stream" -Uri $url -OutFile $output
+Write-Host "Done."
 Expand-Archive -Force -Path $output -DestinationPath "$PSScriptRoot\toolchain\"
 
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/libs/n64/latest/libmikmod.zip"
 $output = "$PSScriptRoot\temp\libmikmod.zip"
 
-Invoke-WebRequest -Uri $url -OutFile $output
+Write-Host "Downloading libmikmod.zip...." -NoNewline
+Invoke-RestMethod -ContentType "application/octet-stream" -Uri $url -OutFile $output
+Write-Host "Done."
 Expand-Archive -Path $output -DestinationPath "$PSScriptRoot"
 
 
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/libs/n64/latest/libmad.zip"
 $output = "$PSScriptRoot\temp\libmad.zip"
 
-Invoke-WebRequest -Uri $url -OutFile $output
+Write-Host "Downloading libmad.zip...." -NoNewline
+Invoke-RestMethod -ContentType "application/octet-stream" -Uri $url -OutFile $output
+Write-Host "Done."
 Expand-Archive -Path $output -DestinationPath "$PSScriptRoot"
 
 
 $url = "https://n64tools.blob.core.windows.net/binaries/N64-tools/libs/n64/latest/libyaml.zip"
 $output = "$PSScriptRoot\temp\libyaml.zip"
 
-Invoke-WebRequest -Uri $url -OutFile $output
+Write-Host "Downloading libyaml.zip...." -NoNewline
+Invoke-RestMethod -ContentType "application/octet-stream" -Uri $url -OutFile $output
+Write-Host "Done."
 Expand-Archive -Path $output -DestinationPath "$PSScriptRoot"
 
 


### PR DESCRIPTION
These two changes should help a lot with the current build status.

Firstly, the nested path in the zip makes it to where the bin folder is located at:
`toolchain/gcc-toolchain-mips64/gcc-toolchain-mips64-win64/bin/`

I have fixed it to where it extracts directly to the `toolchain` folder, and modified the Makefile and scripts with the new location.
The results is the path being as follows:
`toolchain/gcc-toolchain-mips64-win64/bin/`

For the other fix, default `Invoke-WebRequest` is SUPER slow, mainly due to the progress bar actually eating up processing itself.
1. Changing it to where the Progress is silent drops the download from 6 minutes to 1 & 1/2 minutes for me.
2. Changing it to Invoke-RestMethod with the ContentType argument set to application/octet-stream drops another minute off of the time, making it 30 seconds to download.
3. I added Write-Host lines to at least notify the user that it is actually doing things, since the progress has to be hidden to improve the download speed.

6 minutes vs 30 seconds. I think that's worthy of the change. :P

See [here](https://stackoverflow.com/questions/28682642/powershell-why-is-using-invoke-webrequest-much-slower-than-a-browser-download#) for more info.